### PR TITLE
Draft changes - moving the NX documentation into sections & sub-sections

### DIFF
--- a/docs/source/arc-gfx-interactive.rst
+++ b/docs/source/arc-gfx-interactive.rst
@@ -1,33 +1,11 @@
-
-Using the ARC Graphical Nodes
------------------------------
-
-.. warning::
-   This service is currently in beta test and we welcome feedback on the provided features and applications. Be aware that as the service 
-   is under development it is likely to interruption and change.   
-
-ARC have a number of graphical interactive nodes which you can use to interact with applications which require GUI operation, such as RStudio, Jupyter Notebooks
-and ANSYS Workbench.
-
-In order to use these interactive nodes, you must be connected to the university network or be remotely connected via the university VPN service. 
-
-Accessing the Graphical nodes via a web browser
-===============================================
-
-You can connect directly via web browser to `nx.arc.ox.ac.uk <https://nx.arc.ox.ac.uk>`_ via the web-based client connection (which is lower quality in terms of
-visual display). See `Configuring NoMachine Web Client <https://arc-user-guide.readthedocs.io/en/latest/arc-nx-web.html>`_
-
-Accessing the Graphical nodes via the client software
-=====================================================
-
-You may download the `NoMachine Enterprise Client <https://www.nomachine.com/download-enterprise#NoMachine-Enterprise-Client>`_ and install this on your
-local machine. See `Configuring NoMachine Client <https://arc-user-guide.readthedocs.io/en/latest/arc-nx-client.html>`_
-
-  
 Using the ARC desktop environment
 =================================
 
-Once you have connected to the NoMachine server by one of the above methods you will be presented with the ARC desktop environment as shown below:
+ARC have a number of graphical interactive nodes which you can use to interact with applications which require GUI operation (such as RStudio, Jupyter Notebooks and ANSYS Workbench).
+
+In order to use these interactive nodes, you must be connected to the university network or be remotely connected via the university VPN service. See  `Connecting to ARC <https://arc-user-guide.readthedocs.io/en/latest/connecting-to-arc.html>`_ for details how to connect to the graphical nodes.
+
+Once you have connected to the NoMachine service by one of the described methods, you will be presented with the ARC desktop environment as shown below:
 
 .. image:: images/arc-desktop.png
   :width: 800
@@ -41,7 +19,7 @@ You can use the menu bar at the bottom of the window to access applications or, 
   
 .. note::
   While it may look like you have your own Linux desktop to work with, the interactive nodes where you are running this desktop are 
-  shared with other ARC users, and therefore it is very important that you do not run computationally demanding jobs. 
+  shpared with other ARC users, and therefore it is very important that you do not run computationally demanding jobs. 
   
   To run applications that are more demanding, please open a ``Konsole`` shell window and start an interactive X11 
   session on a compute node by following the instructions below:
@@ -58,7 +36,7 @@ You can use the menu bar at the bottom of the window to access applications or, 
                 
               
 Running applications from the desktop
-=====================================
+-------------------------------------
   
 There are a number of predefined applications which you can find under the ``ARC`` sub-menu, within the ``Applications`` section of the main menu bar, see below for examples:
   
@@ -77,5 +55,3 @@ Clicking on these menu items will start up the appropriate version of the specif
 .. note::
    If you need customised versions of applications or supporting modules (such as custom Anaconda virtual environments) you should load/activate and run these as
    appropriate from the ``Konsole`` command window, in the same way as the ARC or HTC systems.
-   
-   

--- a/docs/source/connecting-to-arc.rst
+++ b/docs/source/connecting-to-arc.rst
@@ -40,12 +40,7 @@ MobaXterm for Windows can be found at `https://mobaxterm.mobatek.net/ <https://m
 Connecting using ARC Graphical Nodes
 ------------------------------------
 
-.. warning::
-   This service is currently in beta test and we welcome feedback on the provided features and applications. Be aware that as the service 
-   is under development it is likely to interruption and change.   
-
-ARC have a number of graphical interactive nodes which you can use to interact with applications which require GUI operation, such as RStudio, Jupyter Notebooks
-and ANSYS Workbench. This service uses NoMachine NX for 
+ARC have a number of graphical interactive nodes which you can use to interact with applications which require GUI operation, such as RStudio, Jupyter Notebooks and ANSYS Workbench. This service uses NoMachine NX to provide a remote desktop environemnt.
 
 In order to use these interactive nodes, you **must** be connected to the university network or be remotely connected via the university VPN service. 
 
@@ -60,60 +55,3 @@ Accessing the Graphical nodes via the client software
 
 You may download the `NoMachine Enterprise Client <https://www.nomachine.com/download-enterprise#NoMachine-Enterprise-Client>`_ and install this on your
 local machine. See `Configuring NoMachine Client <https://arc-user-guide.readthedocs.io/en/latest/arc-nx-client.html>`_
-
-  
-Using the ARC desktop environment
-=================================
-
-Once you have connected to the NoMachine server by one of the methods described in `Connecting to ARC <https://arc-user-guide.readthedocs.io/en/latest/connecting-to-arc.html>`_, you will be presented with the ARC desktop environment as shown below:
-
-.. image:: images/arc-desktop.png
-  :width: 800
-  :alt: ARC Desktop
-  
-You can use the menu bar at the bottom of the window to access applications or, as in the example below, open the ``Konsole`` terminal window:
-
-.. image:: images/arc-konsole.png
-  :width: 800
-  :alt: ARC Konsole
-  
-.. note::
-  While it may look like you have your own Linux desktop to work with, the interactive nodes where you are running this desktop are 
-  shared with other ARC users, and therefore it is very important that you do not run computationally demanding jobs. 
-  
-  To run applications that are more demanding, please open a ``Konsole`` shell window and start an interactive X11 
-  session on a compute node by following the instructions below:
-              
-  To run an interactive session on the ARC cluster::
-  
-     module load cluster/arc
-     srun -p interactive --x11 --pty /bin/bash
-    
-  To run an interactive session on the HTC system::
-                
-     module load cluster/htc
-     srun -p interactive --x11 --pty /bin/bash
-                
-              
-Running applications from the desktop
--------------------------------------
-  
-There are a number of predefined applications which you can find under the ``ARC`` sub-menu, within the ``Applications`` section of the main menu bar, see below for examples:
-  
-  .. image:: images/arc-apps1.png
-    :width: 800
-    :alt: ARC Apps Menu
-  
-Applications|ARC Sub-menu 
-  
-  .. image:: images/arc-apps2.png
-    :width: 350
-    :alt: ARC Apps List
-
-Clicking on these menu items will start up the appropriate version of the specified application, with any other required modules automatically loaded.
-
-.. note::
-   If you need customised versions of applications or supporting modules (such as custom Anaconda virtual environments) you should load/activate and run these as
-   appropriate from the ``Konsole`` command window, in the same way as the ARC or HTC systems.
-   
-   

--- a/docs/source/connecting-to-arc.rst
+++ b/docs/source/connecting-to-arc.rst
@@ -45,18 +45,18 @@ Connecting using ARC Graphical Nodes
    is under development it is likely to interruption and change.   
 
 ARC have a number of graphical interactive nodes which you can use to interact with applications which require GUI operation, such as RStudio, Jupyter Notebooks
-and ANSYS Workbench.
+and ANSYS Workbench. This service uses NoMachine NX for 
 
 In order to use these interactive nodes, you **must** be connected to the university network or be remotely connected via the university VPN service. 
 
 Accessing the Graphical nodes via a web browser
-===============================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can connect directly via web browser to `nx.arc.ox.ac.uk <https://nx.arc.ox.ac.uk>`_ via the web-based client connection (which is lower quality in terms of
 visual display). See `Configuring NoMachine Web Client <https://arc-user-guide.readthedocs.io/en/latest/arc-nx-web.html>`_
 
 Accessing the Graphical nodes via the client software
-=====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You may download the `NoMachine Enterprise Client <https://www.nomachine.com/download-enterprise#NoMachine-Enterprise-Client>`_ and install this on your
 local machine. See `Configuring NoMachine Client <https://arc-user-guide.readthedocs.io/en/latest/arc-nx-client.html>`_
@@ -65,7 +65,7 @@ local machine. See `Configuring NoMachine Client <https://arc-user-guide.readthe
 Using the ARC desktop environment
 =================================
 
-Once you have connected to the NoMachine server by one of the above methods you will be presented with the ARC desktop environment as shown below:
+Once you have connected to the NoMachine server by one of the methods described in `Connecting to ARC <https://arc-user-guide.readthedocs.io/en/latest/connecting-to-arc.html>`_, you will be presented with the ARC desktop environment as shown below:
 
 .. image:: images/arc-desktop.png
   :width: 800
@@ -96,7 +96,7 @@ You can use the menu bar at the bottom of the window to access applications or, 
                 
               
 Running applications from the desktop
-=====================================
+-------------------------------------
   
 There are a number of predefined applications which you can find under the ``ARC`` sub-menu, within the ``Applications`` section of the main menu bar, see below for examples:
   

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ ARC User Guide
    arc-systems
    connecting-to-arc
    arc-copying-data
+   arc-gfx-interactive
    arc-script-basics
    job-scheduling
    arc-priority-jobs


### PR DESCRIPTION
Hello,

I've made the 'connecting with the client software' and 'connecting via web' subsubsections, so left the 'connect to the graphical nodes' under Connecting; and I've left a 'using the desktop environment' as a section, but  moved 'running applications' into it.